### PR TITLE
Actualization

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,3 @@
-application: GAE_PROJECT_NAME
-version: 1
 runtime: python27
 api_version: 1
 threadsafe: yes
@@ -11,3 +9,5 @@ handlers:
 libraries:
 - name: webapp2
   version: "2.5.2"
+- name: ssl
+  version: latest

--- a/bot_gae.py
+++ b/bot_gae.py
@@ -2,7 +2,7 @@
 
 import sys
 import os
-sys.path.append(os.path.join(os.path.abspath('.'), 'venv/Lib/site-packages'))
+sys.path.append(os.path.join(os.path.abspath('.'), 'venv/lib/site-packages'))
 
 import telegram
 from flask import Flask, request
@@ -17,7 +17,7 @@ bot = telegram.Bot(token='TOKEN')
 def webhook_handler():
     if request.method == "POST":
         # retrieve the message in JSON and then transform it to Telegram object
-        update = telegram.Update.de_json(request.get_json(force=True))
+        update = telegram.Update.de_json(request.get_json(force=True), bot)
 
         chat_id = update.message.chat.id
 


### PR DESCRIPTION
Parameters `application` and `version` in `app.yaml` prevent deploy app using `gcloud`:
`ERROR: The [application] field is specified in file [./app.yml]. This field is not used by gcloud and must be removed. Project name should insted be specified either by 'gcloud config set project MY_PROJECT' or by setting the '--project' flag on individual command executions.`
`ERROR: The [version] field is specified in file [./app.yml]. This field is not used by gcloud and must be removed. Versions are generated automatically by default but can also be manually specified by setting the '--project' flag on individual command executions.`

To set webhook required library `ssl`.
Now static method `telegram.Update.de_json()` takes exactly 2 arguments - `data (dict)` and `bot (telegram.Bot)`
